### PR TITLE
Update pages with Evelyn

### DIFF
--- a/archivalitems.html
+++ b/archivalitems.html
@@ -31,7 +31,7 @@
   <ul>
     <li><a href="index.html"><i>Return Home</i></a></li>
     <li><a href="digitalarchive.html">What is a Digital Archive?</a></li>
-    <li class="current-link"><a href="archivalitems.html">Do I Have Archival Items?</a></li>
+    <li class="current-link"><a href="archivalitems.html">Records Retention Schedule</a></li>
     <li><a href="emailarchives.html">Email Recommendations</a></li>
     <li><a href="digitalrecords.html">Digital Material Recommendations</a></li>
     <li><a href="recordsday.html">Records Day</a></li>
@@ -49,7 +49,7 @@
 		<h3 id="top">Do I Have Archival Items?</h3>
 		<h4>Reading the Records Retention Schedule</h4>
 		<p>Nearly every department creates content with historical value but the type and amount varies. The Archives has spent time creating a comprehensive Records Retention Schedule to assist staff with identifying important records, you'll find your department listed below.</p> 
-		<p><i>Do you think you have something that isn't included? Please contact us! [archivalmail@bam.org]</i>
+		<p><i>Do you think you have something that isn't included? Please contact us! [archivalemail@bam.org]</i>
 		</p>
 	</article>
 </div>
@@ -131,7 +131,7 @@
 				<th nowrap>AS-3</th>
 				<th>Correspondence</th>
 				<th>Interesting correspondence with artists, in email or paper form.</th>
-				<th>Forward emails or letters to archives@bam.org as they occur, or annually on Record Clean-Up Day.</th>
+				<th>Forward emails or letters to archivalemail@bam.org as they occur, or annually on Record Clean-Up Day.</th>
 			</tr>
 
 			<tr>
@@ -168,7 +168,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Stacey Dinner</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -243,7 +243,7 @@
 				<th>Remove 7 years after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -314,7 +314,7 @@
 				<th>Remove 7 years after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Kevin McLoughlin</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>	
@@ -485,7 +485,7 @@
 				<th>Remove 7 yrs after termination or final payment</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -544,7 +544,7 @@
 				<th>Remove 7 yrs after termination or final payment</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 
 			<p><u>Department Records Coordinator</u>: Katerina Patouri</p>	
 			<p><i><a href="#top">Return to top</a></i></p>
@@ -598,7 +598,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>			
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>			
 			<p><u>Department Records Coordinator</u>: Andrea Drogeanu</p>		
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -662,7 +662,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>					
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -740,7 +740,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>	
 
 			<p><i><a href="#top">Return to top</a></i></p>
@@ -797,8 +797,8 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
-			<p><u>Department Records Coordinator</u>: TBD</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
+			<p><u>Department Records Coordinator</u>: Chantal Bernard</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
 </div>
@@ -883,7 +883,7 @@
 				<th>Remove 7 yrs after termination or final payment</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Shu Shun Xie</p>		
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -996,7 +996,7 @@
 				<th>Web Site</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Paige Haroldson</p>	
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -1067,7 +1067,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Barbara Cummings</p>	
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -1101,7 +1101,7 @@
 				<th nowrap>ED-5</th>
 				<th>Curriculum/Virtual Season Materials -- Video</th>
 				<th>Videos used in curriculums and study guides.</th>
-				<th>IT uploads to Cloud from Video Department Server in summer following seasons</th>
+				<th>Video department transfers viewing copy to Archives server and IT transfers master and viewing copies to remote deep storage server (Glacier). The goal is to do this as soon after the season as possible.</th>
 			</tr>
 			<tr>
 				<th nowrap>ED-6</th>
@@ -1173,7 +1173,7 @@
 				<th>Remove within 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>			
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -1216,7 +1216,8 @@
 			<tr>
 				<th nowrap>EBR-5</th>
 				<th>Board Member Bios</th>
-				<th>Biographical information about Board members including photographs when available.</th			>
+				<th>Biographical information about Board members including photographs when available.
+				</th>
 			</tr>
 			<tr>
 				<th nowrap>EBR-6</th>
@@ -1256,22 +1257,22 @@
 				<th nowrap>EBR-8</th>
 				<th>Board Correspondence</th>
 				<th>Memoranda, announcements, and other correspondence about routine matters sent to Board members.</th>
-				<th>while useful</th>
+				<th>Remove when no longer useful.</th>
 			</tr>
 			<tr>
 				<th nowrap>EBR-12</th>
 				<th>Departmental Budgets</th>
 				<th>Annual budgets and supporting documentation, including drafts and contingency budgets.				</th>
-				<th>while useful, up to 3 yrs</th>
+				<th>Remove when no longer useful, or within 3 years.</th>
 			</tr>
 			<tr>
 				<th nowrap>EBR-13</th>
 				<th>Contract and Legal Agreements--Official Copies</th>
 				<th>Original signed copy of any contract or agreement entered into by this department.</th>
-				<th>7 yrs after termination or final payment</th>
+				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Ali Biss</p>	
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -1294,8 +1295,13 @@
 				<th nowrap>EX-1</th>
 				<th>Subject Files--Significant Content</th>
 				<th>Correspondence, reports, planning documents, other records that contain significant information about BAM's operations or programs or about BAM's involvement with specific organizations, government agencies, companies, persons, events, projects, or activities.</th>
-				<th>TBD</th>
+				<th>Submit to Archives when no longer deemed useful.</th>
 			</tr>
+			<tr>
+				<th nowrap>EX-2</th>
+				<th>Email Records</th>
+				<th>All saved messages in individual accounts except content deemed by the producer to be non-work related.</th>
+				<th>IT transfers to Archives annually on Records Day.</th>
 			<tr>
 				<th colspan="4" class="table-title">Maintain Within Department</th>
 			</tr>
@@ -1303,7 +1309,7 @@
 				<th colspan="4">No records currently in this category.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will not have an automated disposition period.</p>
+			<p>Email Correspondence (General) will not have an automated destruction period.</p>
 			<p><u>Department Records Coordinator</u>: Contact Archives Department</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -1434,34 +1440,34 @@
 				<th nowrap>FI-10</th>
 				<th>Budget planning records</th>
 				<th>Budget worksheets and other records.</th>
-				<th>3 yrs after budget is approved</th>
+				<th>Remove 3 yrs after budget is approved.</th>
 			</tr>
 			<tr>
 				<th nowrap>FI-13</th>
 				<th>Insurance Records</th>
 				<th>Policies, riders, claims, and related documents</th>
-				<th>7 yrs after expiration and settlement of all claims</th>
+				<th>Remove 7 yrs after expiration and settlement of all claims.</th>
 			</tr>
 			<tr>
 				<th nowrap>FI-22</th>
 				<th>Litigation Files</th>
 				<th>For litigation and insurance claims.</th>
-				<th>7 yrs after resolution</th>
+				<th>Remove 7 yrs after resolution.</th>
 			</tr>
 			<tr>
 				<th nowrap>FI-24</th>
 				<th>Departmental Budgets</th>
 				<th>Annual budgets and supporting documentation, including drafts and contingency budgets.</th>
-				<th>while useful, up to 3 yrs</th>
+				<th>Remove when no longer useful, or within 3 yrs.</th>
 			</tr>
 			<tr>
 				<th nowrap>FI-25</th>
 				<th>Contract and Legal Agreements--Official Copies</th>
 				<th>Original signed copy of any contract or agreement entered into by this department.</th>
-				<th>7 yrs after termination or final payment</th>
+				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>	
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>	
 			<p><u>Department Records Coordinator</u>: Tameka White</p>		
 			<p><i><a href="#top">Return to top</a></i></p>
 		</article>
@@ -1475,16 +1481,7 @@
 				<th colspan="4" class="table-title">Send to the Archives</th>
 			</tr>
 			<tr>
-				<th><i>Item</i></th>
-				<th><i>Record Series</i></th>
-				<th><i>Description</i></th>
-				<th><i>Direction</i></th>
-			</tr>
-			<tr>
-				<th nowrap>FS-2</th>
-				<th>Contribution Files--BAM Endowment</th>
-				<th>Records related to gifts to the BAM Endowment.</th>
-				<th>Transfer on Records Day.</th>
+				<th colspan="4">All files maintained within department at this time.</th>
 			</tr>
 			<tr>
 				<th colspan="4" class="table-title">Maintain Within Department</th>
@@ -1500,6 +1497,12 @@
 				<th>Contribution File</th>
 				<th>Records related to gifts to BAM .</th>
 				<th>Remove after a min of 7 yrs after last giving activity.</th>
+			</tr>
+			<tr>
+				<th nowrap>FS-2</th>
+				<th>Contribution Files--BAM Endowment</th>
+				<th>Records related to gifts to the BAM Endowment.</th>
+				<th>Maintain permanently within department.</th>
 			</tr>
 			<tr>
 				<th nowrap>FS-3</th>
@@ -1525,7 +1528,7 @@
 				<th>Remove when no longer useful or within 3 yrs.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>	
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>	
 			<p><u>Department Records Coordinator</u>: Adam Sachs, Claudia Bailey</p>
 
 			<p><i><a href="#top">Return to top</a></i></p>
@@ -1569,13 +1572,13 @@
 				<th nowrap>GM-3</th>
 				<th>Union Negotiation Records</th>
 				<th>Other records for unions with which General Manager is involved.</th>
-				<th>3 yrs after termination of agreement</th>
+				<th>Remove 3 yrs after termination of agreement.</th>
 			</tr>
 			<tr>
 				<th nowrap>GM-4</th>
 				<th>Grievance Records</th>
 				<th>Investigative records, hearing records, other documents for employees of unions with which General Manager is involved.</th>
-				<th>min 10 yrs after resolution</th>
+				<th>Remove no less than 10 yrs after resolution, or when no longer useful.</th>
 			</tr>
 			<tr>
 				<th nowrap>GM-5</th>
@@ -1590,7 +1593,7 @@
 				<th>Remove 7 yrs after termination or final payment</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Liz Zieminski</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -1665,7 +1668,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -1724,7 +1727,7 @@
 				<th>Remove when no longer useful, or within 3 yrs.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Semra Ercin</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -1816,7 +1819,7 @@
 				<th>Remove 30 yrs after termination of employment.</th>
 			</tr>
 			<tr>
-				<th nowrap>HR-6</th>
+				<th nowrap>HR-10</th>
 				<th>Employee Medical Records, Other</th>
 				<th>Health insurance information, medical histories, diagnoses, test results, descriptions of treatment, opinions, notes prepared by health professional--included in employee's medical file.</th>
 				<th>Remove 7 yrs after termination of employment or health coverage, whichever is longer.</th>
@@ -1876,7 +1879,7 @@
 			</tr>
 
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Ariel Rivera</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -1894,6 +1897,12 @@
 				<th><i>Record Series</i></th>
 				<th><i>Description</i></th>
 				<th><i>Direction</i></th>
+			</tr>
+			<tr>
+				<th nowrap>HU-3</th>
+				<th>Video Recordings, Finals</th>
+				<th>For selected significant programs, may just be clips produced for marketing purposes.</th>
+				<th>Video department transfers viewing copy to Archives server and IT transfers master and viewing copies to remote deep storage server (Glacier). The goal is to do this as soon after the season as possible.</th>
 			</tr>
 			<tr>
 				<th nowrap>HU-4</th>
@@ -1944,12 +1953,6 @@
 				<th>Remove when no longer useful.</th>
 			</tr>
 			<tr>
-				<th nowrap>HU-3</th>
-				<th>Video Recordings, Finals</th>
-				<th>For selected significant programs, may just be clips produced for marketing purposes.</th>
-				<th>Maintain while useful, then Video dept will upload directly to cloud storage. </th>
-			</tr>
-			<tr>
 				<th nowrap>HU-8</th>
 				<th>Departmental Budgets</th>
 				<th>Annual budgets and supporting documentation, including drafts and contingency budgets.</th>
@@ -1962,7 +1965,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Molly Silberberg</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2030,7 +2033,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2053,13 +2056,13 @@
 				<th nowrap>MK-7</th>
 				<th>Marketing email campaigns</th>
 				<th>Marketing materials sent to various recipient groups to promote events at BAM.</th>
-				<th>Include archivalmail@bam.org on all mailing lists.</th>
+				<th>Include archivalemail@bam.org on all mailing lists.</th>
 			</tr>
 			<tr>
 				<th nowrap>MK-1</th>
 				<th>Print Media Records</th>
 				<th>Physical copies of brochures and other marketing materials for BAM events; in printed form, arranged chronologically by season.</th>
-				<th rowspan="2">Send to Archives on Records Cleanup Day following previous season.</th>
+				<th rowspan="2">Send to Archives following previous season.</th>
 			</tr>
 			<tr>
 				<th nowrap>MK-2</th>
@@ -2100,7 +2103,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Anna Troester</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2134,7 +2137,7 @@
 				<th nowrap>ME-11</th>
 				<th>Targeted Membership Email Outreach</th>
 				<th>Communication with members about various events and BAM activity.</th>
-				<th>Include archivalmail@bam.org on all mailing lists.</th>
+				<th>Include archivalemail@bam.org on all mailing lists.</th>
 			</tr>
 			<tr>
 				<th colspan="4" class="table-title">Maintain within the Department</th>
@@ -2149,7 +2152,7 @@
 				<th nowrap>ME-1</th>
 				<th>Membership Records</th>
 				<th>Information about members including contact information, ticket purchase history, selected correspondence, contributions, etc.</th>
-				<th>Remove after a min of 25 yrs after last activity, including last ticketing activity for former members.</th>
+				<th>Remove after a min of 25 yrs after last activity, including last ticketing activity for former members (this information is stored in Tessitura).</th>
 			</tr>
 			<tr>
 				<th nowrap>ME-5</th>
@@ -2186,7 +2189,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Cheryl-Lyn Miller</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2262,7 +2265,7 @@
 				<th>Remove when superseded.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Jessica Hindle</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2276,16 +2279,7 @@
 				<th colspan="4" class="table-title">Send to the Archives</th>
 			</tr>
 			<tr>
-				<th><i>Item</i></th>
-				<th><i>Record Series</i></th>
-				<th><i>Description</i></th>
-				<th><i>Direction</i></th>
-			</tr>
-			<tr>
-				<th nowrap>PL-4</th>
-				<th>Gift Acceptance Policy</th>
-				<th>Approved policy on procedures for accepting gifts.</th>
-				<th>Submit on Records Cleanup Day.</th>
+				<th colspan="4">All records permanently maintained within the department at this time.</th>
 			</tr>
 			<tr>
 				<th colspan="4" class="table-title">Maintain within the Department</th>
@@ -2314,13 +2308,19 @@
 				<th>Financial Statements, Annual Filings, Tax Documents, and other documentation relating to charitable gift annuity agreements.</th>
 			</tr>
 			<tr>
+				<th nowrap>PL-4</th>
+				<th>Gift Acceptance Policy</th>
+				<th>Approved policy on procedures for accepting gifts.</th>
+				<th>Submit on Records Cleanup Day.</th>
+			</tr>
+			<tr>
 				<th nowrap>PL-5</th>
 				<th>Departmental Budgets</th>
 				<th>Annual budgets and supporting documentation, including drafts and contingency budgets.</th>
 				<th>Remove when no longer useful or within 3 yrs.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2389,7 +2389,7 @@
 				<th>Remove when no longer useful, or within 3 yrs.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Heli Soell</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2457,8 +2457,23 @@
 				<th>Original signed copy of any contract or agreement entered into by this department.</th>
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
+			<tr>
+				<th nowrap>PG 8</th>
+				<th>Subject Files</th>
+				<th>Covering areas of scholarly or historical interest about the institution and its artistic programming choices.</th>
+				<th rowspan="3">Transfer digital files when no longer in use. Submit paper records on Records Cleanup Day.</th>
+			<tr>
+				<th nowrap>PG 9</th>
+				<th>Season Files</th>
+				<th>Contains for the season for each production: marketing assets, contract, show description, and tech rider.  Also contains the season calendar.</th>
+			</tr>
+			<tr>
+				<th nowrap>PG 10</th>
+				<th>Photographs</th>
+				<th>Photographs taken by the Office of Artistic Programming</th>
+			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Stonie Darling</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2516,7 +2531,7 @@
 				<th>Remove 7 yrs after termination or final payment</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2539,17 +2554,12 @@
 				<th nowrap>SE-2</th>
 				<th>Selected Materials From Event Files</th>
 				<th>For events with noteworthy guests or other extraordinary features, selected photos with clear rights and metadata, correspondence, printed materials, other documents of historical or scholarly value.</th>
-				<th rowspan="3">Transfer on Records Cleanup Day.</th>
+				<th rowspan="2">Transfer digital and physical files by each summer for the previous year. Where only one physical version exists, it should stay within the department's permanent file because it will be needed for reference within the department.</th>
 			</tr>
 			<tr>
 				<th nowrap>SE-3</th>
 				<th>Gala Files</th>
 				<th>Invitations, guest lists, program/journal, selected photos, other descriptive information available.</th>
-			</tr>
-			<tr>
-				<th nowrap>SE-1</th>
-				<th>Event Files</th>
-				<th>Correspondence/email, printed materials, timelines, selected photos, contracts, other documents.</th>
 			</tr>
 			<tr>
 				<th colspan="4" class="table-title">Maintain within Department</th>
@@ -2559,6 +2569,12 @@
 				<th><i>Record Series</i></th>
 				<th><i>Description</i></th>
 				<th><i>Direction</i></th>
+			</tr>
+			<tr>
+				<th nowrap>SE-1</th>
+				<th>Event Files</th>
+				<th>Correspondence/email, printed materials, timelines, selected photos, contracts, other documents.</th>
+				<th>Maintain permanently within the department.</th>
 			</tr>
 			<tr>
 				<th nowrap>SE-4</th>
@@ -2573,7 +2589,7 @@
 				<th>Remove 7 yrs after termination or final payment</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2649,7 +2665,7 @@
 				<th>Remove 7 yrs after termination or final payment</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Christine Gruder</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2709,7 +2725,7 @@
 				<th>Remove 7 yrs after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Royda Venture</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2732,23 +2748,23 @@
 				<th nowrap>VI-1</th>
 				<th>Masters, Final Copy</th>
 				<th>Final Copy, Archive Videos, Mainstage Productions, Marketing Promotional Videos, non-Mainstage performances, E+H performances, Digital Curriculum Videos.</th>
-				<th>Directly transferred to deep storage. Additionally, videos of Mainstage productions are transferred to NYPL per agreement</th>
+				<th rowspan="3">Video department transfers viewing copy to Archives server and IT transfers master and viewing copies to remote deep storage server (Glacier). The goal is to do this as soon after the season as possible. Additionally, video deparment transfers videos of mainstage productions to NYPL per agreement.</th>
 			</tr>
 			<tr>
 				<th nowrap>VI-2</th>
 				<th>Viewing Copies--Final Copy</th>
 				<th>Final derivative viewing copies made of any masters.</th>
-				<th rowspan="3">Transfer on Records Cleanup Day.</th>
 			</tr>
 			<tr>
-				<th nowrap>VI-9</th>
-				<th>Audio Recordings--Finals</th>
-				<th>Audio recordings of Humanities events, talks, programs, etc.  (Note:  most audio files are recorded by stagehands and are transferred to Archives by the Humanities Department.)</th>
+				<th nowrap>VI-3</th>
+				<th>Social Media Photos and Videos, Final Copy</th>
+				<th>Unique photos and videos made for specific social media platform.</th>
 			</tr>
 			<tr>
 				<th nowrap>VI-11</th>
 				<th>Master Shoot List</th>
 				<th>Master Shoot List of information relating to all recording activity by the Video Department.</th>
+				<th>Transfer on Records Cleanup Day.</th>
 			</tr>
 			<tr>
 				<th colspan="4" class="table-title">Maintain within Department</th>
@@ -2760,16 +2776,10 @@
 				<th><i>Direction</i></th>
 			</tr>
 			<tr>
-				<th nowrap>VI-3</th>
-				<th>Social Media Photos and Videos, Final Copy</th>
-				<th>Unique photos and videos made for specific social media platform.</th>
-				<th>TBD</th>
-			</tr>
-			<tr>
 				<th nowrap>VI-4</th>
 				<th>Internal Use Promotional Videos (Sizzle Reels), Final Copy</th>
 				<th>Videos requested by departments for business presentations or any internal purposes</th>
-				<th rowspan="4">Remove when no longer useful.</th>
+				<th rowspan="2">Store for potential future use (IT will transfer to long-term, Glacier storage); remove if no longer needed after 5 years.</th>
 			</tr>
 			<tr>
 				<th nowrap>VI-5</th>
@@ -2780,6 +2790,7 @@
 				<th nowrap>VI-12</th>
 				<th>Work Requests</th>
 				<th>Requests for projects submitted online by BAM departments</th>
+				<th rowspan="2">Remove when no longer useful.</th>
 			</tr>
 			<tr>
 				<th nowrap>VI-14</th>
@@ -2802,7 +2813,7 @@
 				<th nowrap>VI-8</th>
 				<th>Footage from Artists</th>
 				<th>Audio and video sent to BAM from artist or company.</th>
-				<th>Discard after performance at BAM.</th>
+				<th>Discard after performance at BAM, or when no longer useful.</th>
 			</tr>
 			<tr>
 				<th nowrap>VI-10</th>
@@ -2817,7 +2828,7 @@
 				<th>Remove 7 years after termination or final payment.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: Ben Katz</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
@@ -2874,14 +2885,14 @@
 				<th>Written communication with artists and curators.</th>
 			</tr>
 			</table>
-			<p>Email Correspondence (General) will be set for an automated disposition 7 years after creation.</p>
+			<p>Email Correspondence (General) will be set for an automated destruction 7 years after creation.</p>
 			<p><u>Department Records Coordinator</u>: TBD</p>
 			<p><i><a href="#top">Return to top</a></i></p>
 	</article>
 </div>
 
 <footer>
-<p><i>When in doubt, contact the archives! Feel free to email any questions or concerns to archivalmail@bam.org.</i></p>
+<p><i>When in doubt, contact the archives! Feel free to email any questions or concerns to archivalemail@bam.org.</i></p>
 </footer>
 </div>
 

--- a/digitalarchive.html
+++ b/digitalarchive.html
@@ -31,7 +31,7 @@
   <ul>
     <li><a href="index.html"><i>Return Home</i></a></li>
     <li class="current-link"><a href="digitalarchive.html">What is a Digital Archive?</a></li>
-    <li><a href="archivalitems.html">Do I Have Archival Items?</a></li>
+    <li><a href="archivalitems.html">Records Retention Schedule</a></li>
     <li><a href="emailarchives.html">Email Recommendations</a></li>
     <li><a href="digitalrecords.html">Digital Material Recommendations</a></li>
     <li><a href="recordsday.html">Records Day</a></li>
@@ -95,13 +95,13 @@
 		<article>
 			<p>The Archives has been collecting and preserving digital photographs and videos of performances for many years and as many of  the institution’s documents became digitally produced, like press releases, programs, and annual reports, those have been collected and preserved, as well.</p>
 
-			<p>The <a href="levyarchive.bam.org">Leon Levy Digital Archive</a> is an online searchable catalog of the institution’s records that are of most interest, particularly performance and artist-related materials.  This is available to the public.</p>
+			<p>The <a href="http://levyarchive.bam.org/">Leon Levy Digital Archive</a> is an online searchable catalog of the institution’s records that are of most interest, particularly performance and artist-related materials.  This is available to the public.</p>
 
  			<p>The Archives is also responsible for collecting and preserving institutional records, many of which are now produced in digital format.  These are preserved on an Archives’ server and will be available to staff and researchers interested in understanding BAM’s past.  The records collected are outlined in the Records Retention Schedule in the next section.</p>
 		</article>
 
 		<article class="page-content">
-			<h4 class="next-steps"><a href="archivalitems.html">NEXT STEPS: Do I Have Archival Items?</a></h4>
+			<h4 class="next-steps"><a href="archivalitems.html">NEXT STEPS: Records Retention Schedule</a></h4>
 
 
 		</article>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 <nav>
   <ul>
     <li><a href="digitalarchive.html">What is a Digital Archive?</a></li>
-    <li><a href="archivalitems.html">Do I Have Archival Items?</a></li>
+    <li><a href="archivalitems.html">Records Retention Schedule</a></li>
     <li><a href="emailarchives.html">Email Recommendations</a></li>
     <li><a href="digitalrecords.html">Digital Material Recommendations</a></li>
     <li><a href="recordsday.html">Records Day</a></li>
@@ -50,7 +50,7 @@
 		<h3>Table of Contents</h3>
 		<p><a href="digitalarchive.html">What is a Digital Archive?</a><br>
 		<i>*According to archival science and what this means at BAM.</i></p>
-		<p><a href="archivalitems.html">Do I Have Archival Items?</a><br>
+		<p><a href="archivalitems.html">Records Retention Schedule</a><br>
 		<i>*A complete list of material by departments.</i></p>
 		<p><a href="emailarchives.html">Email Recommendations</a><br>
 		<i>*Deciding what to save, an easy way to use folders and rules, and additional resources.</i></p>
@@ -61,7 +61,7 @@
 		</article>
 	</div>
 
-	<p id="content-info">The Staff Handbook serves as your central resource for information related to the handling of records, especially digital records on-site at BAM. Here you'll find helpful recommendations for managing your email, maintaining department records, information about Records Day, and a detailed breakdown of the types of files we collect for the Archives. This site is continually in development and if you feel there is anything missing, please contact us at archivalmail@bam.org.</p>
+	<p id="content-info">The Staff Handbook serves as your central resource for information related to the handling of records, especially digital records on-site at BAM. Here you'll find helpful recommendations for managing your email, maintaining department records, information about Records Day, and a detailed breakdown of the types of files we collect for the Archives. This site is continually in development and if you feel there is anything missing, please contact us at archivalemail@bam.org.</p>
 
 
 </div>


### PR DESCRIPTION
Not to repeat, but need to include Records Retention Schedule in title or replace “Do I Have Archival Items?” with “BAM’s Records Retention Schedule” or similar.

General:  the standard footer about email says it will be set for “an automated disposition 7 years after creation.”  Wasn’t sure why you said “disposition” instead of “destruction.”  

Records retention schedule:
AS3-may be fine, but want to check use of that email with Louie.
ED4 & ED5 direction:  Video Department transfers viewing copy to Archives server and IT transfers master and viewing copies to remote deep storage server (Glacier).  Goal is to do this as soon after the season as possible.
EBR8,12,13—Use your new format for direction using verb (ie., “Remove when no longer useful” rather than “while useful”
Add EX-2 as a category since it is a permanent record, with the description saying it’s the email correspondence of the four major executive officers,etc.
Finance section: modify direction section to your new format using verb F10-25.
FS2- changed- doesn’t go to Archives, stays permanent within department.
GM3,4—modify direction to new format using verb.
HU3 is for the Archive.  Direction: Video Department transfers viewing copy to Archives server and IT transfers master and viewing copies to remote deep storage server (Glacier).  Goal is to do this as soon after the season as possible.
HR6 Employee Medical Records looks like a typo—should be HR10.
MK7 – archivalemail
MK1 modify direction:  Send to Archives on Records Cleanup Day following previous season
ME11- archivalemail
add to direction—“(This information is stored in Tessitura.)”
PL4- change to maintain permanently within department.
Add 3 new categories – all have same direction “Transfer digital files when no longer in use.  If there are any paper records, submit on Records Cleanup Day.”
PG 8- Subject Files : Covering areas of scholarly or historical interest about the institution and its artistic programming choices.
PG 9- Season Files : Contains for the season for each production: marketing assets, contract, show description, and tech rider.  Also contains the season calendar.
PG 10- Photographs: Photographs taken by the Office of Artistic Programming
PM4-delete.  PM 5&6 become 4&5.
SE 1 – permanent with department—doesn’t go to Archives.
SE 2, 3 Modify Direction: Transfer digital files by each summer for the previous year.  Where only one physical copy exists, it should stay in the department’s permanent file because it will be needed for reference by the department. 
VI9- Eliminate
VI3 – Move into “to go to Archives” area
VI-1,2,3  Direction: Video Department transfers viewing copy to Archives server and IT transfers master and viewing copies to remote deep storage server (Glacier).  Goal is to do this as soon after the season as possible.  Additionally, Video Department transfers videos of mainstage productions to NYPL per agreement.
VI4,5- Store for potential future use (IT will transfer to long-term Glacier storage); remove if no longer needed after five years.
